### PR TITLE
fix: flash species table values invisible after merge

### DIFF
--- a/ui/properties_panel.py
+++ b/ui/properties_panel.py
@@ -255,6 +255,7 @@ class PropertiesPanel(QWidget):
             QHeaderView.ResizeMode.Stretch)
         self._flash_species_table.setMinimumHeight(80)
         self._flash_species_table.setMaximumHeight(160)
+        self._flash_species_table.setStyleSheet("QTableWidget::item { color: black; }")
         self._flash_species_table.cellChanged.connect(self._on_flash_species_changed)
         flash_form.addRow(self._flash_species_table)
 


### PR DESCRIPTION
## Summary

The `QTableWidget::item { color: black; }` stylesheet was applied to `_flash_species_table` in `feat/flash-separator` but was lost when the two fix branches merged into main independently.

## Root cause

`fix/species-table-render` was based on main (pre-Flash Separator), so it only patched `_species_table`. When `feat/flash-separator` merged, its version of `properties_panel.py` didn't include the flash table stylesheet line, overwriting the fix for that table.

## Test plan

- [ ] Drop a Flash Separator on the canvas, select it — Antoine constants should be visible immediately without clicking