### PR TITLE
feat(canvas): pinch-to-zoom, palette dark mode, canvas fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ build/
 case_study.md
 PLAN.md
 .claude/
+TODO.md

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ build/
 .DS_Store
 case_study.md
 PLAN.md
+.claude/

--- a/tests/test_absorption.py
+++ b/tests/test_absorption.py
@@ -1,0 +1,298 @@
+"""Unit tests for models/absorption.py — simulate_absorption() and AbsorptionConfig."""
+import math
+import pytest
+import numpy as np
+
+from models.absorption import AbsorptionConfig, PACKING_DATABASE, simulate_absorption
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def default_result():
+    """Run with default AbsorptionConfig and return the result dict."""
+    return simulate_absorption(AbsorptionConfig())
+
+
+# ---------------------------------------------------------------------------
+# AbsorptionConfig defaults
+# ---------------------------------------------------------------------------
+
+class TestAbsorptionConfig:
+    def test_default_instantiation(self):
+        cfg = AbsorptionConfig()
+        assert cfg.y_in == 0.13
+        assert cfg.y_out == 0.0005
+        assert cfg.x_in == 0.0
+        assert cfg.packing == "Ralu Ring 25mm"
+
+    def test_custom_values_stored(self):
+        cfg = AbsorptionConfig(y_in=0.10, y_out=0.001, T=310.0)
+        assert cfg.y_in == 0.10
+        assert cfg.y_out == 0.001
+        assert cfg.T == 310.0
+
+
+# ---------------------------------------------------------------------------
+# Return-dict structure
+# ---------------------------------------------------------------------------
+
+class TestReturnStructure:
+    EXPECTED_KEYS = {
+        "z", "y", "x", "y_star", "HOG", "HETP", "kG_a", "kL_a", "KOG_a",
+        "NOG", "HOG_bottom", "HOG_top", "HOG_mean",
+        "HETP_bottom", "HETP_top", "HETP_mean",
+        "H_col", "delta_P",
+        "R_gas_pct", "R_liq_pct",
+        "L_molar", "L_mass", "L_molar_min", "u_L", "u_G_Fl",
+        "u_G_actual", "loading_frac", "lambda_val", "A_abs",
+        "L_factor", "x_out", "m",
+        "success", "message",
+    }
+
+    def test_all_keys_present(self):
+        res = default_result()
+        assert self.EXPECTED_KEYS.issubset(res.keys())
+
+    def test_profile_arrays_length(self):
+        cfg = AbsorptionConfig(n_points=50)
+        res = simulate_absorption(cfg)
+        for key in ("z", "y", "x", "y_star", "HOG", "HETP", "kG_a", "kL_a", "KOG_a"):
+            assert len(res[key]) == 50, f"Array '{key}' has wrong length"
+
+    def test_all_scalars_are_finite(self):
+        res = default_result()
+        scalar_keys = [
+            "NOG", "HOG_bottom", "HOG_top", "HOG_mean",
+            "HETP_bottom", "HETP_top", "HETP_mean",
+            "H_col", "delta_P", "R_gas_pct", "R_liq_pct",
+            "L_molar", "L_mass", "L_molar_min", "u_L", "u_G_Fl",
+            "u_G_actual", "loading_frac", "lambda_val", "L_factor", "x_out", "m",
+        ]
+        for key in scalar_keys:
+            assert math.isfinite(res[key]), f"Scalar '{key}' is not finite"
+
+
+# ---------------------------------------------------------------------------
+# Profile array consistency
+# ---------------------------------------------------------------------------
+
+class TestProfileArrays:
+    def test_y_array_endpoints(self):
+        cfg = AbsorptionConfig(y_in=0.13, y_out=0.0005)
+        res = simulate_absorption(cfg)
+        assert res["y"][0] == pytest.approx(cfg.y_in)
+        assert res["y"][-1] == pytest.approx(cfg.y_out)
+
+    def test_z_array_starts_at_zero(self):
+        res = default_result()
+        assert res["z"][0] == pytest.approx(0.0)
+
+    def test_z_array_monotonically_increasing(self):
+        res = default_result()
+        assert np.all(np.diff(res["z"]) >= 0)
+
+    def test_z_last_equals_H_col(self):
+        res = default_result()
+        assert res["z"][-1] == pytest.approx(res["H_col"], rel=1e-6)
+
+    def test_x_array_consistent_with_operating_line(self):
+        cfg = AbsorptionConfig()
+        res = simulate_absorption(cfg)
+        # x(y) = (G/L) * (y - y_out) + x_in  — check a few points
+        GoverL = res["L_factor"]  # not stored, recalculate via x_out
+        # x_out is at y_in: verify endpoint
+        assert res["x"][0] == pytest.approx(res["x_out"], rel=1e-6)
+        assert res["x"][-1] == pytest.approx(cfg.x_in, abs=1e-10)
+
+    def test_y_star_equals_m_times_x(self):
+        res = default_result()
+        np.testing.assert_allclose(res["y_star"], res["m"] * res["x"], rtol=1e-10)
+
+    def test_HOG_array_is_constant(self):
+        res = default_result()
+        assert np.all(res["HOG"] == res["HOG"][0])
+
+    def test_HETP_array_is_constant(self):
+        res = default_result()
+        assert np.all(res["HETP"] == res["HETP"][0])
+
+    def test_kG_a_array_is_constant(self):
+        res = default_result()
+        assert np.all(res["kG_a"] == res["kG_a"][0])
+
+
+# ---------------------------------------------------------------------------
+# Physical constraints
+# ---------------------------------------------------------------------------
+
+class TestPhysicalConstraints:
+    def test_H_col_positive(self):
+        assert default_result()["H_col"] > 0.0
+
+    def test_NOG_positive(self):
+        assert default_result()["NOG"] > 0.0
+
+    def test_delta_P_positive(self):
+        assert default_result()["delta_P"] > 0.0
+
+    def test_resistance_percentages_sum_to_100(self):
+        res = default_result()
+        total = res["R_gas_pct"] + res["R_liq_pct"]
+        assert total == pytest.approx(100.0, abs=1e-6)
+
+    def test_resistance_percentages_in_range(self):
+        res = default_result()
+        assert 0.0 < res["R_gas_pct"] < 100.0
+        assert 0.0 < res["R_liq_pct"] < 100.0
+
+    def test_L_molar_greater_than_L_min(self):
+        res = default_result()
+        assert res["L_molar"] > res["L_molar_min"]
+
+    def test_L_factor_preserved(self):
+        cfg = AbsorptionConfig(L_factor=1.8)
+        res = simulate_absorption(cfg)
+        assert res["L_factor"] == pytest.approx(1.8)
+
+    def test_u_G_actual_matches_config(self):
+        cfg = AbsorptionConfig(u_G=0.8)
+        res = simulate_absorption(cfg)
+        assert res["u_G_actual"] == pytest.approx(0.8)
+
+    def test_x_out_positive(self):
+        assert default_result()["x_out"] > 0.0
+
+    def test_m_positive(self):
+        assert default_result()["m"] > 0.0
+
+    def test_A_abs_is_inverse_of_lambda(self):
+        res = default_result()
+        assert res["A_abs"] == pytest.approx(1.0 / res["lambda_val"], rel=1e-10)
+
+    def test_HOG_mean_equals_H_col_over_NOG(self):
+        res = default_result()
+        assert res["HOG_mean"] == pytest.approx(res["H_col"] / res["NOG"], rel=5e-2)
+
+
+# ---------------------------------------------------------------------------
+# Hydraulic check
+# ---------------------------------------------------------------------------
+
+class TestHydraulicCheck:
+    # For the default packing (Ralu Ring 25mm) the flooding velocity is ~0.041 m/s,
+    # so we use u_G=0.02 m/s for the "not flooding" tests.
+    _safe_cfg = AbsorptionConfig(u_G=0.02)
+
+    def test_non_flooding_config_is_ok(self):
+        res = simulate_absorption(self._safe_cfg)
+        assert res["success"] is True
+        assert res["message"] == "OK"
+
+    def test_loading_fraction_below_one_when_ok(self):
+        res = simulate_absorption(self._safe_cfg)
+        assert res["loading_frac"] < 1.0
+
+    def test_flooding_detected(self):
+        # u_G=0.05 m/s > u_G_Fl (~0.041 m/s) for the default packing
+        cfg = AbsorptionConfig(u_G=0.05)
+        res = simulate_absorption(cfg)
+        assert res["success"] is False
+        assert res["loading_frac"] >= 1.0
+        assert "Flooding" in res["message"]
+
+    def test_loading_frac_increases_with_u_G(self):
+        res_low  = simulate_absorption(AbsorptionConfig(u_G=0.01))
+        res_high = simulate_absorption(AbsorptionConfig(u_G=0.03))
+        assert res_high["loading_frac"] > res_low["loading_frac"]
+
+
+# ---------------------------------------------------------------------------
+# Sensitivity / monotonicity
+# ---------------------------------------------------------------------------
+
+class TestSensitivity:
+    def test_H_col_increases_with_stricter_spec(self):
+        """Requiring lower y_out demands a taller column."""
+        res_easy = simulate_absorption(AbsorptionConfig(y_out=0.01))
+        res_hard = simulate_absorption(AbsorptionConfig(y_out=0.0005))
+        assert res_hard["H_col"] > res_easy["H_col"]
+
+    def test_H_col_increases_with_higher_y_in(self):
+        """More CO₂ to remove → taller column."""
+        res_low  = simulate_absorption(AbsorptionConfig(y_in=0.05, y_out=0.001))
+        res_high = simulate_absorption(AbsorptionConfig(y_in=0.20, y_out=0.001))
+        assert res_high["H_col"] > res_low["H_col"]
+
+    def test_H_col_decreases_with_higher_L_factor(self):
+        """More solvent flow → fewer transfer units / shorter column."""
+        res_lo = simulate_absorption(AbsorptionConfig(L_factor=1.2))
+        res_hi = simulate_absorption(AbsorptionConfig(L_factor=2.5))
+        assert res_hi["H_col"] < res_lo["H_col"]
+
+    def test_NOG_increases_with_stricter_spec(self):
+        res_easy = simulate_absorption(AbsorptionConfig(y_out=0.01))
+        res_hard = simulate_absorption(AbsorptionConfig(y_out=0.0005))
+        assert res_hard["NOG"] > res_easy["NOG"]
+
+    def test_delta_P_increases_with_u_G(self):
+        res_lo = simulate_absorption(AbsorptionConfig(u_G=0.5))
+        res_hi = simulate_absorption(AbsorptionConfig(u_G=1.5))
+        assert res_hi["delta_P"] > res_lo["delta_P"]
+
+
+# ---------------------------------------------------------------------------
+# Equilibrium slope (m)
+# ---------------------------------------------------------------------------
+
+class TestEquilibriumSlope:
+    def test_m_equals_H_px_over_P(self):
+        cfg = AbsorptionConfig(H_px=3.4e7, P=101325.0)
+        res = simulate_absorption(cfg)
+        assert res["m"] == pytest.approx(cfg.H_px / cfg.P, rel=1e-10)
+
+    def test_higher_H_px_gives_larger_m(self):
+        res_lo = simulate_absorption(AbsorptionConfig(H_px=1e7))
+        res_hi = simulate_absorption(AbsorptionConfig(H_px=5e7))
+        assert res_hi["m"] > res_lo["m"]
+
+
+# ---------------------------------------------------------------------------
+# Packing database coverage
+# ---------------------------------------------------------------------------
+
+class TestPackingDatabase:
+    @pytest.mark.parametrize("packing", list(PACKING_DATABASE.keys()))
+    def test_all_packings_run_without_error(self, packing):
+        cfg = AbsorptionConfig(packing=packing)
+        res = simulate_absorption(cfg)
+        assert res["H_col"] > 0.0
+        assert math.isfinite(res["H_col"])
+
+    def test_unknown_packing_raises(self):
+        cfg = AbsorptionConfig(packing="NonExistentPacking")
+        with pytest.raises(KeyError):
+            simulate_absorption(cfg)
+
+
+# ---------------------------------------------------------------------------
+# HETP formula for lambda ≈ 1
+# ---------------------------------------------------------------------------
+
+class TestHETPLambdaEdgeCase:
+    def test_HETP_equals_HOG_when_lambda_is_one(self):
+        """When λ = 1 the HETP formula degenerates to HETP = HOG."""
+        # λ = m · G / L = m / (L_factor / stripping denominator)
+        # Easier to set H_px and P so m = L_molar / G_molar exactly.
+        # We tune via binary search instead: just assert the branch is reached
+        # by constructing a near-unity lambda config and check HETP ≈ HOG.
+        # (The code checks abs(lambda-1) < 1e-6.)
+        cfg = AbsorptionConfig()
+        res = simulate_absorption(cfg)
+        if abs(res["lambda_val"] - 1.0) < 1e-6:
+            assert res["HETP_mean"] == pytest.approx(res["HOG_mean"])
+        else:
+            # For the default config lambda ≠ 1; just verify log formula is used
+            expected = res["HOG_mean"] * math.log(res["lambda_val"]) / (res["lambda_val"] - 1.0)
+            assert res["HETP_mean"] == pytest.approx(expected, rel=1e-6)

--- a/ui/check.svg
+++ b/ui/check.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 14 14">
+  <polyline points="2,7 6,11 12,3" fill="none" stroke="white" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/ui/flowsheet_canvas.py
+++ b/ui/flowsheet_canvas.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 
 from PyQt6.QtWidgets import (QGraphicsScene, QGraphicsView, QGraphicsItem,
                               QGraphicsLineItem, QMenu)
-from PyQt6.QtCore import Qt, QRectF, QPointF, QLineF, pyqtSignal
+from PyQt6.QtCore import Qt, QRectF, QPointF, QLineF, QEvent, pyqtSignal
 from PyQt6.QtGui import (QPainter, QPen, QBrush, QColor, QFont,
                           QTransform, QAction, QPainterPath)
 
@@ -949,17 +949,34 @@ class FlowsheetView(QGraphicsView):
     # ── zoom ──────────────────────────────────────────────────────────────
 
     _MIN_SCALE = 1.0 / 3.0   # can't zoom out more than 3× the initial scale
-    _MAX_SCALE = 10.0
+    _MAX_SCALE = 2.0
 
     def wheelEvent(self, event):
-        factor = 1.15 if event.angleDelta().y() > 0 else 1.0 / 1.15
-        current = self.transform().m11()
-        new_scale = current * factor
-        if new_scale < self._MIN_SCALE:
-            factor = self._MIN_SCALE / current
-        elif new_scale > self._MAX_SCALE:
-            factor = self._MAX_SCALE / current
-        self.scale(factor, factor)
+        # Two-finger scroll pans the canvas; pinch-to-zoom handles scaling.
+        delta = event.pixelDelta()
+        if delta.isNull():
+            ad = event.angleDelta()
+            delta = QPointF(ad.x() / 8, ad.y() / 8)
+        self.horizontalScrollBar().setValue(
+            self.horizontalScrollBar().value() - int(delta.x())
+        )
+        self.verticalScrollBar().setValue(
+            self.verticalScrollBar().value() - int(delta.y())
+        )
+
+    def event(self, event):
+        if event.type() == QEvent.Type.NativeGesture:
+            if event.gestureType() == Qt.NativeGestureType.ZoomNativeGesture:
+                factor = 1.0 + event.value()
+                current = self.transform().m11()
+                new_scale = current * factor
+                if new_scale < self._MIN_SCALE:
+                    factor = self._MIN_SCALE / current
+                elif new_scale > self._MAX_SCALE:
+                    factor = self._MAX_SCALE / current
+                self.scale(factor, factor)
+                return True
+        return super().event(event)
 
     # ── port detection ────────────────────────────────────────────────────
 

--- a/ui/flowsheet_canvas.py
+++ b/ui/flowsheet_canvas.py
@@ -38,6 +38,14 @@ _PORT_RADIUS = 12   # px — how close cursor must be to snap to a port
 _ACW = 56     # column body width
 _ACH = 100    # column body height
 
+# ── Theme ─────────────────────────────────────────────────────────────────────
+_DARK_MODE: bool = False
+
+
+def set_dark_mode(enabled: bool) -> None:
+    global _DARK_MODE
+    _DARK_MODE = enabled
+
 
 class BatchReactorItem(QGraphicsItem):
     """PFD symbol for a batch reactor, rendered with a custom painter."""
@@ -95,18 +103,14 @@ class BatchReactorItem(QGraphicsItem):
         selected = self.isSelected()
         hovered = self._hovered
 
-        if selected:
-            body_fill = QColor("#85c1e9")
-            border = QColor("#154360")
-            bw = 2.5
-        elif hovered:
-            body_fill = QColor("#aed6f1")
-            border = QColor("#1a5276")
-            bw = 2.0
+        if _DARK_MODE:
+            if selected:   body_fill, border, bw = QColor("#1a5276"), QColor("#5dade2"), 2.5
+            elif hovered:  body_fill, border, bw = QColor("#154060"), QColor("#3498db"), 2.0
+            else:          body_fill, border, bw = QColor("#0d2a40"), QColor("#2980b9"), 1.5
         else:
-            body_fill = QColor("#d6eaf8")
-            border = QColor("#2980b9")
-            bw = 1.5
+            if selected:   body_fill, border, bw = QColor("#85c1e9"), QColor("#154360"), 2.5
+            elif hovered:  body_fill, border, bw = QColor("#aed6f1"), QColor("#1a5276"), 2.0
+            else:          body_fill, border, bw = QColor("#d6eaf8"), QColor("#2980b9"), 1.5
 
         pen = QPen(border, bw)
         brush = QBrush(body_fill)
@@ -130,18 +134,19 @@ class BatchReactorItem(QGraphicsItem):
             painter.drawLine(QPointF(-blen, blade_y), QPointF(blen, blade_y))
 
         if selected:
-            sel_pen = QPen(QColor("#3498db"), 1.2, Qt.PenStyle.DashLine)
+            sel_pen = QPen(QColor("#5dade2") if _DARK_MODE else QColor("#3498db"),
+                           1.2, Qt.PenStyle.DashLine)
             painter.setPen(sel_pen)
             painter.setBrush(Qt.BrushStyle.NoBrush)
             painter.drawRect(self.boundingRect().adjusted(3, 3, -3, -3))
 
-        painter.setPen(QPen(QColor("#1a3a5c")))
+        painter.setPen(QPen(QColor("#85c1e9") if _DARK_MODE else QColor("#1a3a5c")))
         painter.setFont(QFont("", 9, QFont.Weight.Bold))
         painter.drawText(QRectF(-w / 2, h / 2 + 6, w, 18),
                          Qt.AlignmentFlag.AlignCenter, self.name)
 
         painter.setFont(QFont("", 7))
-        painter.setPen(QPen(QColor("#5d6d7e")))
+        painter.setPen(QPen(QColor("#95a5a6") if _DARK_MODE else QColor("#5d6d7e")))
         rstr = self.reaction.reaction_label()
         if len(rstr) > 12:
             rstr = rstr[:11] + "…"
@@ -242,18 +247,14 @@ class CSTRReactorItem(QGraphicsItem):
         selected = self.isSelected()
         hovered = self._hovered
 
-        if selected:
-            body_fill = QColor("#a9dfbf")
-            border = QColor("#145a32")
-            bw = 2.5
-        elif hovered:
-            body_fill = QColor("#abebc6")
-            border = QColor("#1e8449")
-            bw = 2.0
+        if _DARK_MODE:
+            if selected:   body_fill, border, bw = QColor("#186a3b"), QColor("#58d68d"), 2.5
+            elif hovered:  body_fill, border, bw = QColor("#145a32"), QColor("#2ecc71"), 2.0
+            else:          body_fill, border, bw = QColor("#0d3320"), QColor("#27ae60"), 1.5
         else:
-            body_fill = QColor("#d5f5e3")
-            border = QColor("#27ae60")
-            bw = 1.5
+            if selected:   body_fill, border, bw = QColor("#a9dfbf"), QColor("#145a32"), 2.5
+            elif hovered:  body_fill, border, bw = QColor("#abebc6"), QColor("#1e8449"), 2.0
+            else:          body_fill, border, bw = QColor("#d5f5e3"), QColor("#27ae60"), 1.5
 
         pen = QPen(border, bw)
         brush = QBrush(body_fill)
@@ -287,18 +288,19 @@ class CSTRReactorItem(QGraphicsItem):
             painter.drawLine(QPointF(-blen, blade_y), QPointF(blen, blade_y))
 
         if selected:
-            sel_pen = QPen(QColor("#2ecc71"), 1.2, Qt.PenStyle.DashLine)
+            sel_pen = QPen(QColor("#58d68d") if _DARK_MODE else QColor("#2ecc71"),
+                           1.2, Qt.PenStyle.DashLine)
             painter.setPen(sel_pen)
             painter.setBrush(Qt.BrushStyle.NoBrush)
             painter.drawRect(self.boundingRect().adjusted(3, 3, -3, -3))
 
-        painter.setPen(QPen(QColor("#145a32")))
+        painter.setPen(QPen(QColor("#a9dfbf") if _DARK_MODE else QColor("#145a32")))
         painter.setFont(QFont("", 9, QFont.Weight.Bold))
         painter.drawText(QRectF(-w / 2, h / 2 + 6, w, 18),
                          Qt.AlignmentFlag.AlignCenter, self.name)
 
         painter.setFont(QFont("", 7))
-        painter.setPen(QPen(QColor("#5d6d7e")))
+        painter.setPen(QPen(QColor("#95a5a6") if _DARK_MODE else QColor("#5d6d7e")))
         rstr = self.reaction.reaction_label()
         if len(rstr) > 12:
             rstr = rstr[:11] + "…"
@@ -307,7 +309,7 @@ class CSTRReactorItem(QGraphicsItem):
 
         # Port indicators (shown when hovered or selected)
         if hovered or selected:
-            painter.setBrush(QBrush(QColor("#ffffff")))
+            painter.setBrush(QBrush(QColor("#0f0f0f") if _DARK_MODE else QColor("#ffffff")))
             painter.setPen(QPen(border, 1.5))
             painter.drawEllipse(QPointF(-w / 2 - 22, -h / 4), 5, 5)
             painter.drawEllipse(QPointF(w / 2 + 22, h / 4), 5, 5)
@@ -383,18 +385,14 @@ class HeaterCoolerItem(QGraphicsItem):
         selected = self.isSelected()
         hovered = self._hovered
 
-        if selected:
-            body_fill = QColor("#f0b27a")
-            border = QColor("#a04000")
-            bw = 2.5
-        elif hovered:
-            body_fill = QColor("#fad7a0")
-            border = QColor("#d35400")
-            bw = 2.0
+        if _DARK_MODE:
+            if selected:   body_fill, border, bw = QColor("#5a3100"), QColor("#f39c12"), 2.5
+            elif hovered:  body_fill, border, bw = QColor("#4a2800"), QColor("#e67e22"), 2.0
+            else:          body_fill, border, bw = QColor("#2e1800"), QColor("#d35400"), 1.5
         else:
-            body_fill = QColor("#fdebd0")
-            border = QColor("#e67e22")
-            bw = 1.5
+            if selected:   body_fill, border, bw = QColor("#f0b27a"), QColor("#a04000"), 2.5
+            elif hovered:  body_fill, border, bw = QColor("#fad7a0"), QColor("#d35400"), 2.0
+            else:          body_fill, border, bw = QColor("#fdebd0"), QColor("#e67e22"), 1.5
 
         pen = QPen(border, bw)
         w, h = _HW, _HH
@@ -420,18 +418,19 @@ class HeaterCoolerItem(QGraphicsItem):
             _draw_wave_line(painter, x0, wave_y, inner_w, h / 9, 3)
 
         if selected:
-            sel_pen = QPen(QColor("#e67e22"), 1.2, Qt.PenStyle.DashLine)
+            sel_pen = QPen(QColor("#f39c12") if _DARK_MODE else QColor("#e67e22"),
+                           1.2, Qt.PenStyle.DashLine)
             painter.setPen(sel_pen)
             painter.setBrush(Qt.BrushStyle.NoBrush)
             painter.drawRect(self.boundingRect().adjusted(3, 3, -3, -3))
 
-        painter.setPen(QPen(QColor("#784212")))
+        painter.setPen(QPen(QColor("#f0b27a") if _DARK_MODE else QColor("#784212")))
         painter.setFont(QFont("", 9, QFont.Weight.Bold))
         painter.drawText(QRectF(-w / 2, h / 2 + 4, w, 18),
                          Qt.AlignmentFlag.AlignCenter, self.name)
 
         painter.setFont(QFont("", 7))
-        painter.setPen(QPen(QColor("#784212")))
+        painter.setPen(QPen(QColor("#cd8b4a") if _DARK_MODE else QColor("#784212")))
         hint = f"\u2192 {self.config.T_target:.1f} K"
         painter.drawText(QRectF(-w / 2, -h / 2 + 3, w, 14),
                          Qt.AlignmentFlag.AlignCenter, hint)
@@ -439,7 +438,7 @@ class HeaterCoolerItem(QGraphicsItem):
         # Output port indicator (shown when hovered or selected)
         if hovered or selected:
             port_local = QPointF(w / 2 + 22, 0)
-            painter.setBrush(QBrush(QColor("#ffffff")))
+            painter.setBrush(QBrush(QColor("#0f0f0f") if _DARK_MODE else QColor("#ffffff")))
             painter.setPen(QPen(border, 1.5))
             painter.drawEllipse(port_local, 5, 5)
 
@@ -506,18 +505,14 @@ class FlashSeparatorItem(QGraphicsItem):
         selected = self.isSelected()
         hovered = self._hovered
 
-        if selected:
-            body_fill = QColor("#aed6f1")
-            border = QColor("#1a5276")
-            bw = 2.5
-        elif hovered:
-            body_fill = QColor("#d6eaf8")
-            border = QColor("#2980b9")
-            bw = 2.0
+        if _DARK_MODE:
+            if selected:   body_fill, border, bw = QColor("#1a3d52"), QColor("#5dade2"), 2.5
+            elif hovered:  body_fill, border, bw = QColor("#122d42"), QColor("#3498db"), 2.0
+            else:          body_fill, border, bw = QColor("#0a1e2e"), QColor("#2980b9"), 1.5
         else:
-            body_fill = QColor("#ebf5fb")
-            border = QColor("#5dade2")
-            bw = 1.5
+            if selected:   body_fill, border, bw = QColor("#aed6f1"), QColor("#1a5276"), 2.5
+            elif hovered:  body_fill, border, bw = QColor("#d6eaf8"), QColor("#2980b9"), 2.0
+            else:          body_fill, border, bw = QColor("#ebf5fb"), QColor("#5dade2"), 1.5
 
         w, h = _FW, _FH
 
@@ -538,7 +533,7 @@ class FlashSeparatorItem(QGraphicsItem):
 
         # Phase labels
         painter.setFont(QFont("", 7, QFont.Weight.Bold))
-        painter.setPen(QPen(QColor("#1a5276")))
+        painter.setPen(QPen(QColor("#85c1e9") if _DARK_MODE else QColor("#1a5276")))
         painter.drawText(QRectF(-w / 2, -h / 2 + 4, w, 14),
                          Qt.AlignmentFlag.AlignCenter, "V")
         painter.drawText(QRectF(-w / 2 + 10, h / 2 - 18, w - 10, 14),
@@ -559,23 +554,24 @@ class FlashSeparatorItem(QGraphicsItem):
         _draw_arrowhead(painter, w / 2 + 22, h / 4, 6, border)
 
         if selected:
-            painter.setPen(QPen(QColor("#2980b9"), 1.2, Qt.PenStyle.DashLine))
+            painter.setPen(QPen(QColor("#5dade2") if _DARK_MODE else QColor("#2980b9"),
+                                1.2, Qt.PenStyle.DashLine))
             painter.setBrush(Qt.BrushStyle.NoBrush)
             painter.drawRect(self.boundingRect().adjusted(3, 3, -3, -3))
 
-        painter.setPen(QPen(QColor("#1a5276")))
+        painter.setPen(QPen(QColor("#85c1e9") if _DARK_MODE else QColor("#1a5276")))
         painter.setFont(QFont("", 9, QFont.Weight.Bold))
         painter.drawText(QRectF(-w / 2, h / 2 + 6, w, 18),
                          Qt.AlignmentFlag.AlignCenter, self.name)
 
         painter.setFont(QFont("", 7))
-        painter.setPen(QPen(QColor("#5d6d7e")))
+        painter.setPen(QPen(QColor("#95a5a6") if _DARK_MODE else QColor("#5d6d7e")))
         painter.drawText(QRectF(-w / 2, -h / 2 - 18, w, 14),
                          Qt.AlignmentFlag.AlignCenter, f"T = {self.config.T:.0f} K")
 
         # Port indicators (shown when hovered or selected)
         if hovered or selected:
-            painter.setBrush(QBrush(QColor("#ffffff")))
+            painter.setBrush(QBrush(QColor("#0f0f0f") if _DARK_MODE else QColor("#ffffff")))
             painter.setPen(QPen(border, 1.5))
             painter.drawEllipse(QPointF(-w / 2 - 22, 0), 5, 5)
             painter.drawEllipse(QPointF(w / 2 + 22, -h / 4), 5, 5)
@@ -633,18 +629,14 @@ class AbsorptionColumnItem(QGraphicsItem):
         selected = self.isSelected()
         hovered  = self._hovered
 
-        if selected:
-            body_fill = QColor("#a2d9ce")
-            border    = QColor("#0e6655")
-            bw = 2.5
-        elif hovered:
-            body_fill = QColor("#c0ece5")
-            border    = QColor("#148f77")
-            bw = 2.0
+        if _DARK_MODE:
+            if selected:   body_fill, border, bw = QColor("#133d2e"), QColor("#1abc9c"), 2.5
+            elif hovered:  body_fill, border, bw = QColor("#0d3828"), QColor("#17b89a"), 2.0
+            else:          body_fill, border, bw = QColor("#072920"), QColor("#148f77"), 1.5
         else:
-            body_fill = QColor("#d1f2eb")
-            border    = QColor("#1abc9c")
-            bw = 1.5
+            if selected:   body_fill, border, bw = QColor("#a2d9ce"), QColor("#0e6655"), 2.5
+            elif hovered:  body_fill, border, bw = QColor("#c0ece5"), QColor("#148f77"), 2.0
+            else:          body_fill, border, bw = QColor("#d1f2eb"), QColor("#1abc9c"), 1.5
 
         w, h = _ACW, _ACH
         pen   = QPen(border, bw)
@@ -685,14 +677,14 @@ class AbsorptionColumnItem(QGraphicsItem):
         _draw_arrowhead(painter, -w / 2 - 22, h / 4, 6, border)
 
         # Name label below
-        painter.setPen(QPen(QColor("#0e6655")))
+        painter.setPen(QPen(QColor("#a2d9ce") if _DARK_MODE else QColor("#0e6655")))
         painter.setFont(QFont("", 9, QFont.Weight.Bold))
         painter.drawText(QRectF(-w / 2, h / 2 + 6, w, 18),
                          Qt.AlignmentFlag.AlignCenter, self.name)
 
         # Packing hint above
         painter.setFont(QFont("", 7))
-        painter.setPen(QPen(QColor("#5d6d7e")))
+        painter.setPen(QPen(QColor("#95a5a6") if _DARK_MODE else QColor("#5d6d7e")))
         packing_short = self.config.packing.split()[0] + " " + self.config.packing.split()[1] \
             if len(self.config.packing.split()) >= 2 else self.config.packing
         painter.drawText(QRectF(-w / 2, -h / 2 - 18, w, 14),
@@ -745,7 +737,7 @@ class StreamItem(QGraphicsItem):
         except Exception:
             return
 
-        color = QColor("#7f8c8d")
+        color = QColor("#e3e3e3") if _DARK_MODE else QColor("#7f8c8d")
         painter.setPen(QPen(color, 2.0))
         painter.setBrush(Qt.BrushStyle.NoBrush)
         painter.drawPath(path)
@@ -851,6 +843,14 @@ class FlowsheetScene(QGraphicsScene):
                 return s.source
         return None
 
+    # ── theme ─────────────────────────────────────────────────────────────
+
+    def set_dark_mode(self, enabled: bool) -> None:
+        set_dark_mode(enabled)
+        for item in self.items():
+            item.update()
+        self.update()
+
     # ── notifications ─────────────────────────────────────────────────────
 
     def _notify_selected(self, item):
@@ -932,11 +932,11 @@ class FlowsheetView(QGraphicsView):
     # ── background grid ───────────────────────────────────────────────────
 
     def drawBackground(self, painter: QPainter, rect: QRectF):
-        painter.fillRect(rect, QColor("#fafafa"))
+        painter.fillRect(rect, QColor("#0f0f0f") if _DARK_MODE else QColor("#fafafa"))
         grid = 25
         left = int(rect.left()) - (int(rect.left()) % grid)
         top = int(rect.top()) - (int(rect.top()) % grid)
-        dot_pen = QPen(QColor("#d5d8dc"), 1)
+        dot_pen = QPen(QColor("#1e1e1e") if _DARK_MODE else QColor("#d5d8dc"), 1)
         painter.setPen(dot_pen)
         x = left
         while x <= int(rect.right()) + grid:
@@ -989,7 +989,8 @@ class FlowsheetView(QGraphicsView):
                 self._conn_source_port = port
                 self._temp_line = self.scene().addLine(
                     QLineF(port, port),
-                    QPen(QColor("#7f8c8d"), 1.5, Qt.PenStyle.DashLine))
+                    QPen(QColor("#e3e3e3") if _DARK_MODE else QColor("#7f8c8d"),
+                         1.5, Qt.PenStyle.DashLine))
                 self.setCursor(Qt.CursorShape.CrossCursor)
                 return
 

--- a/ui/flowsheet_canvas.py
+++ b/ui/flowsheet_canvas.py
@@ -1063,9 +1063,13 @@ class FlowsheetView(QGraphicsView):
     def _fit_all(self):
         sc = self.scene()
         br = sc.itemsBoundingRect()
-        if not br.isNull():
-            self.fitInView(br.adjusted(-80, -80, 80, 80),
-                           Qt.AspectRatioMode.KeepAspectRatio)
+        if br.isNull():
+            return
+        vp = self.viewport()
+        if vp.width() < 50 or vp.height() < 50:
+            return
+        self.fitInView(br.adjusted(-80, -80, 80, 80),
+                       Qt.AspectRatioMode.KeepAspectRatio)
 
     # ── drag-and-drop from palette ────────────────────────────────────────
 

--- a/ui/flowsheet_canvas.py
+++ b/ui/flowsheet_canvas.py
@@ -948,8 +948,17 @@ class FlowsheetView(QGraphicsView):
 
     # ── zoom ──────────────────────────────────────────────────────────────
 
+    _MIN_SCALE = 1.0 / 3.0   # can't zoom out more than 3× the initial scale
+    _MAX_SCALE = 10.0
+
     def wheelEvent(self, event):
         factor = 1.15 if event.angleDelta().y() > 0 else 1.0 / 1.15
+        current = self.transform().m11()
+        new_scale = current * factor
+        if new_scale < self._MIN_SCALE:
+            factor = self._MIN_SCALE / current
+        elif new_scale > self._MAX_SCALE:
+            factor = self._MAX_SCALE / current
         self.scale(factor, factor)
 
     # ── port detection ────────────────────────────────────────────────────

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -29,6 +29,9 @@ class MainWindow(QMainWindow):
         self._build_statusbar()
         self._connect()
 
+        self._dark_act.setChecked(True)
+        self._toggle_theme(True)
+
         self._statusbar.showMessage(
             "Drag a Batch Reactor or CSTR from the Equipment palette onto the flowsheet.", 6000)
 
@@ -141,7 +144,7 @@ class MainWindow(QMainWindow):
 
         # Enforce initial widths
         self.resizeDocks([palette_dock], [160], Qt.Orientation.Horizontal)
-        self.resizeDocks([props_dock], [290], Qt.Orientation.Horizontal)
+        self.resizeDocks([props_dock], [380], Qt.Orientation.Horizontal)
 
     def _build_statusbar(self):
         self._statusbar = QStatusBar()
@@ -420,15 +423,20 @@ class MainWindow(QMainWindow):
         self._scene.set_dark_mode(checked)
         self._results.set_dark_mode(checked)
         self._props.set_dark_mode(checked)
+        self._palette.set_dark_mode(checked)
         label_style = "color: #888888;" if checked else "color: #636e72;"
         self._tb_info.setStyleSheet(f"{label_style} font-size: 11px;")
 
     def _fit_view(self):
         br = self._scene.itemsBoundingRect()
-        if not br.isNull():
-            self._canvas.fitInView(
-                br.adjusted(-80, -80, 80, 80),
-                Qt.AspectRatioMode.KeepAspectRatio)
+        if br.isNull():
+            return
+        vp = self._canvas.viewport()
+        if vp.width() < 50 or vp.height() < 50:
+            return
+        self._canvas.fitInView(
+            br.adjusted(-80, -80, 80, 80),
+            Qt.AspectRatioMode.KeepAspectRatio)
 
     def _show_about(self):
         QMessageBox.about(

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -1,5 +1,6 @@
 from PyQt6.QtWidgets import (QMainWindow, QDockWidget, QSplitter,
-                              QStatusBar, QLabel, QMessageBox, QToolBar)
+                              QStatusBar, QLabel, QMessageBox, QToolBar,
+                              QApplication)
 from PyQt6.QtCore import Qt, QSize
 from PyQt6.QtGui import QAction
 
@@ -91,6 +92,13 @@ class MainWindow(QMainWindow):
         fit_a2.setShortcut("Ctrl+F")
         fit_a2.triggered.connect(self._fit_view)
         view_m.addAction(fit_a2)
+
+        view_m.addSeparator()
+        self._dark_act = QAction("Dark Mode", self)
+        self._dark_act.setCheckable(True)
+        self._dark_act.setShortcut("Ctrl+Shift+D")
+        self._dark_act.triggered.connect(self._toggle_theme)
+        view_m.addAction(self._dark_act)
 
         help_m = mb.addMenu("Help")
         about_a = QAction("About Reaktor", self)
@@ -404,6 +412,16 @@ class MainWindow(QMainWindow):
         self._props.clear()
         self._tb_info.setText("  No reactor selected")
         self._statusbar.showMessage("Flowsheet cleared.", 3000)
+
+    def _toggle_theme(self, checked: bool):
+        from ui.styles import DARK_STYLESHEET, LIGHT_STYLESHEET
+        QApplication.instance().setStyleSheet(
+            DARK_STYLESHEET if checked else LIGHT_STYLESHEET)
+        self._scene.set_dark_mode(checked)
+        self._results.set_dark_mode(checked)
+        self._props.set_dark_mode(checked)
+        label_style = "color: #888888;" if checked else "color: #636e72;"
+        self._tb_info.setStyleSheet(f"{label_style} font-size: 11px;")
 
     def _fit_view(self):
         br = self._scene.itemsBoundingRect()

--- a/ui/palette_panel.py
+++ b/ui/palette_panel.py
@@ -12,10 +12,15 @@ class EquipmentTile(QWidget):
         self._label = label
         self._mime_key = mime_key
         self._hovered = False
+        self._dark_mode = False
         self._drag_start: QPoint | None = None
         self.setFixedSize(130, 100)
         self.setCursor(Qt.CursorShape.OpenHandCursor)
         self.setMouseTracking(True)
+
+    def set_dark_mode(self, dark: bool):
+        self._dark_mode = dark
+        self.update()
 
     # ── painting ──────────────────────────────────────────────────────────
 
@@ -23,8 +28,14 @@ class EquipmentTile(QWidget):
         painter = QPainter(self)
         painter.setRenderHint(QPainter.RenderHint.Antialiasing)
 
-        bg = QColor("#ebf5fb") if self._hovered else QColor("#fdfefe")
-        border = QColor("#2980b9") if self._hovered else QColor("#aab7b8")
+        if self._dark_mode:
+            bg = QColor("#1e2e3e") if self._hovered else QColor("#1a1a1a")
+            border = QColor("#2980b9") if self._hovered else QColor("#2a2a2a")
+            label_color = QColor("#a0c8e8")
+        else:
+            bg = QColor("#ebf5fb") if self._hovered else QColor("#fdfefe")
+            border = QColor("#2980b9") if self._hovered else QColor("#aab7b8")
+            label_color = QColor("#1a3a5c")
 
         painter.setBrush(QBrush(bg))
         painter.setPen(QPen(border, 1))
@@ -32,7 +43,7 @@ class EquipmentTile(QWidget):
 
         self._draw_reactor_icon(painter, self.width() // 2, 40, 28, 40)
 
-        painter.setPen(QPen(QColor("#1a3a5c")))
+        painter.setPen(QPen(label_color))
         painter.setFont(QFont("", 9, QFont.Weight.Bold))
         painter.drawText(0, self.height() - 18, self.width(), 18,
                          Qt.AlignmentFlag.AlignHCenter | Qt.AlignmentFlag.AlignVCenter,
@@ -307,65 +318,94 @@ class PalettePanel(QWidget):
         layout.setSpacing(8)
 
         # Section header
-        header = QLabel("EQUIPMENT")
-        header.setStyleSheet(
+        self._header = QLabel("EQUIPMENT")
+        self._header.setStyleSheet(
             "color: #7f8c8d; font-size: 10px; font-weight: bold; letter-spacing: 1px;")
-        layout.addWidget(header)
+        layout.addWidget(self._header)
 
-        sep = QFrame()
-        sep.setFrameShape(QFrame.Shape.HLine)
-        sep.setStyleSheet("color: #bdc3c7;")
-        layout.addWidget(sep)
+        self._sep = QFrame()
+        self._sep.setFrameShape(QFrame.Shape.HLine)
+        self._sep.setStyleSheet("color: #bdc3c7;")
+        layout.addWidget(self._sep)
 
-        cat = QLabel("Reactors")
-        cat.setStyleSheet("color: #1a5276; font-size: 11px; font-weight: bold;")
-        layout.addWidget(cat)
+        self._cat = QLabel("Reactors")
+        self._cat.setStyleSheet("color: #1a5276; font-size: 11px; font-weight: bold;")
+        layout.addWidget(self._cat)
 
-        tile = EquipmentTile("Batch Reactor", "batch_reactor")
-        layout.addWidget(tile, alignment=Qt.AlignmentFlag.AlignHCenter)
+        self._tile = EquipmentTile("Batch Reactor", "batch_reactor")
+        layout.addWidget(self._tile, alignment=Qt.AlignmentFlag.AlignHCenter)
 
-        cstr_tile = CSTREquipmentTile("CSTR", "cstr_reactor")
-        layout.addWidget(cstr_tile, alignment=Qt.AlignmentFlag.AlignHCenter)
+        self._cstr_tile = CSTREquipmentTile("CSTR", "cstr_reactor")
+        layout.addWidget(self._cstr_tile, alignment=Qt.AlignmentFlag.AlignHCenter)
 
-        sep2 = QFrame()
-        sep2.setFrameShape(QFrame.Shape.HLine)
-        sep2.setStyleSheet("color: #bdc3c7;")
-        layout.addWidget(sep2)
+        self._sep2 = QFrame()
+        self._sep2.setFrameShape(QFrame.Shape.HLine)
+        self._sep2.setStyleSheet("color: #bdc3c7;")
+        layout.addWidget(self._sep2)
 
-        cat2 = QLabel("Heat Transfer")
-        cat2.setStyleSheet("color: #784212; font-size: 11px; font-weight: bold;")
-        layout.addWidget(cat2)
+        self._cat2 = QLabel("Heat Transfer")
+        self._cat2.setStyleSheet("color: #784212; font-size: 11px; font-weight: bold;")
+        layout.addWidget(self._cat2)
 
-        heater_tile = HeaterCoolerTile("Heater/Cooler", "heater_cooler")
-        layout.addWidget(heater_tile, alignment=Qt.AlignmentFlag.AlignHCenter)
+        self._heater_tile = HeaterCoolerTile("Heater/Cooler", "heater_cooler")
+        layout.addWidget(self._heater_tile, alignment=Qt.AlignmentFlag.AlignHCenter)
 
-        sep3 = QFrame()
-        sep3.setFrameShape(QFrame.Shape.HLine)
-        sep3.setStyleSheet("color: #bdc3c7;")
-        layout.addWidget(sep3)
+        self._sep3 = QFrame()
+        self._sep3.setFrameShape(QFrame.Shape.HLine)
+        self._sep3.setStyleSheet("color: #bdc3c7;")
+        layout.addWidget(self._sep3)
 
-        cat3 = QLabel("Separation")
-        cat3.setStyleSheet("color: #1a5276; font-size: 11px; font-weight: bold;")
-        layout.addWidget(cat3)
+        self._cat3 = QLabel("Separation")
+        self._cat3.setStyleSheet("color: #1a5276; font-size: 11px; font-weight: bold;")
+        layout.addWidget(self._cat3)
 
-        flash_tile = FlashSeparatorTile("Flash Sep.", "flash_separator")
-        layout.addWidget(flash_tile, alignment=Qt.AlignmentFlag.AlignHCenter)
+        self._flash_tile = FlashSeparatorTile("Flash Sep.", "flash_separator")
+        layout.addWidget(self._flash_tile, alignment=Qt.AlignmentFlag.AlignHCenter)
 
-        sep4 = QFrame()
-        sep4.setFrameShape(QFrame.Shape.HLine)
-        sep4.setStyleSheet("color: #bdc3c7;")
-        layout.addWidget(sep4)
+        self._sep4 = QFrame()
+        self._sep4.setFrameShape(QFrame.Shape.HLine)
+        self._sep4.setStyleSheet("color: #bdc3c7;")
+        layout.addWidget(self._sep4)
 
-        cat4 = QLabel("Gas-Liquid")
-        cat4.setStyleSheet("color: #0e6655; font-size: 11px; font-weight: bold;")
-        layout.addWidget(cat4)
+        self._cat4 = QLabel("Gas-Liquid")
+        self._cat4.setStyleSheet("color: #0e6655; font-size: 11px; font-weight: bold;")
+        layout.addWidget(self._cat4)
 
-        abs_tile = AbsorptionColumnTile("Absorption Col.", "absorption_column")
-        layout.addWidget(abs_tile, alignment=Qt.AlignmentFlag.AlignHCenter)
+        self._abs_tile = AbsorptionColumnTile("Absorption Col.", "absorption_column")
+        layout.addWidget(self._abs_tile, alignment=Qt.AlignmentFlag.AlignHCenter)
 
-        tip = QLabel("Drag onto the\nflowsheet to add")
-        tip.setStyleSheet("color: #95a5a6; font-size: 10px;")
-        tip.setAlignment(Qt.AlignmentFlag.AlignHCenter)
-        layout.addWidget(tip)
+        self._tip = QLabel("Drag onto the\nflowsheet to add")
+        self._tip.setStyleSheet("color: #95a5a6; font-size: 10px;")
+        self._tip.setAlignment(Qt.AlignmentFlag.AlignHCenter)
+        layout.addWidget(self._tip)
 
         layout.addStretch()
+
+    def set_dark_mode(self, dark: bool):
+        if dark:
+            self.setStyleSheet("background-color: #111111;")
+            self._header.setStyleSheet(
+                "color: #555555; font-size: 10px; font-weight: bold; letter-spacing: 1px;")
+            self._cat.setStyleSheet("color: #a0c8e8; font-size: 11px; font-weight: bold;")
+            self._cat2.setStyleSheet("color: #e0a060; font-size: 11px; font-weight: bold;")
+            self._cat3.setStyleSheet("color: #a0c8e8; font-size: 11px; font-weight: bold;")
+            self._cat4.setStyleSheet("color: #5dbea8; font-size: 11px; font-weight: bold;")
+            sep_style = "color: #2a2a2a;"
+            self._tip.setStyleSheet("color: #444444; font-size: 10px;")
+        else:
+            self.setStyleSheet("background-color: #f4f6f7;")
+            self._header.setStyleSheet(
+                "color: #7f8c8d; font-size: 10px; font-weight: bold; letter-spacing: 1px;")
+            self._cat.setStyleSheet("color: #1a5276; font-size: 11px; font-weight: bold;")
+            self._cat2.setStyleSheet("color: #784212; font-size: 11px; font-weight: bold;")
+            self._cat3.setStyleSheet("color: #1a5276; font-size: 11px; font-weight: bold;")
+            self._cat4.setStyleSheet("color: #0e6655; font-size: 11px; font-weight: bold;")
+            sep_style = "color: #bdc3c7;"
+            self._tip.setStyleSheet("color: #95a5a6; font-size: 10px;")
+
+        for sep in (self._sep, self._sep2, self._sep3, self._sep4):
+            sep.setStyleSheet(sep_style)
+
+        for tile in (self._tile, self._cstr_tile, self._heater_tile,
+                     self._flash_tile, self._abs_tile):
+            tile.set_dark_mode(dark)

--- a/ui/properties_panel.py
+++ b/ui/properties_panel.py
@@ -20,8 +20,8 @@ class PropertiesPanel(QWidget):
 
     def __init__(self, parent=None):
         super().__init__(parent)
-        self.setMinimumWidth(260)
-        self.setMaximumWidth(320)
+        self.setMinimumWidth(300)
+        self.setMaximumWidth(420)
         self._item = None               # current flowsheet item
         self._upstream_heater = None    # HeaterCoolerItem connected upstream (CSTR only)
         self._loading = False           # suppress callbacks while populating
@@ -443,9 +443,15 @@ class PropertiesPanel(QWidget):
         layout.addWidget(self._abs_grp)
 
         # Run button
-        self._run_btn = QPushButton("▶  Run Simulation")
+        self._run_btn = QPushButton("▶  Run Selected Block")
         self._run_btn.setObjectName("run_btn")
         self._run_btn.setFixedHeight(36)
+        self._run_btn.setStyleSheet(
+            "QPushButton { background-color: #27ae60; color: white; border: none;"
+            " border-radius: 4px; font-weight: bold; font-size: 12px; }"
+            "QPushButton:hover { background-color: #1e8449; }"
+            "QPushButton:pressed { background-color: #196f3d; }"
+        )
         self._run_btn.clicked.connect(self._on_run)
         layout.addWidget(self._run_btn)
 

--- a/ui/properties_panel.py
+++ b/ui/properties_panel.py
@@ -44,10 +44,10 @@ class PropertiesPanel(QWidget):
         scroll.setFrameShape(QFrame.Shape.NoFrame)
         outer.addWidget(scroll)
 
-        content = QWidget()
-        content.setStyleSheet("background-color: white;")
-        scroll.setWidget(content)
-        self._layout = QVBoxLayout(content)
+        self._content = QWidget()
+        self._content.setStyleSheet("background-color: white;")
+        scroll.setWidget(self._content)
+        self._layout = QVBoxLayout(self._content)
         self._layout.setContentsMargins(10, 10, 10, 10)
         self._layout.setSpacing(10)
 
@@ -65,6 +65,52 @@ class PropertiesPanel(QWidget):
         self._form_widget.setVisible(False)
         self._layout.insertWidget(0, self._form_widget)
         self._build_form()
+
+    # ── theme ─────────────────────────────────────────────────────────────
+
+    def set_dark_mode(self, enabled: bool) -> None:
+        if enabled:
+            self._content.setStyleSheet("background-color: #0f0f0f;")
+            self._title.setStyleSheet(
+                "background-color: #111111; color: #e8e8e8;"
+                "font-size: 12px; font-weight: bold;")
+            self._placeholder.setStyleSheet(
+                "color: #666666; font-size: 12px; margin: 30px 0;")
+            self._reactor_type_lbl.setStyleSheet(
+                "color: #888888; font-size: 10px; font-style: italic;")
+            self._reaction_preview.setStyleSheet(
+                "font-size: 11px; font-weight: bold; color: #85c1e9;"
+                "background: #141414; border-radius: 4px; padding: 4px;")
+            self._species_table.setStyleSheet(
+                "QTableWidget::item { color: #e8e8e8; }")
+            self._tau_display.setStyleSheet("color: #888888; font-size: 10px;")
+            self._flash_species_table.setStyleSheet(
+                "QTableWidget::item { color: #e8e8e8; }")
+            self._abs_adv_btn.setStyleSheet(
+                "QPushButton { text-align: left; font-size: 10px; "
+                "color: #888888; border: none; padding: 2px 0; background: transparent; }"
+                "QPushButton:checked { color: #1abc9c; }")
+        else:
+            self._content.setStyleSheet("background-color: white;")
+            self._title.setStyleSheet(
+                "background-color: #2c5f8a; color: white;"
+                "font-size: 12px; font-weight: bold;")
+            self._placeholder.setStyleSheet(
+                "color: #95a5a6; font-size: 12px; margin: 30px 0;")
+            self._reactor_type_lbl.setStyleSheet(
+                "color: #5d6d7e; font-size: 10px; font-style: italic;")
+            self._reaction_preview.setStyleSheet(
+                "font-size: 11px; font-weight: bold; color: #1a3a5c;"
+                "background: #eaf4fb; border-radius: 4px; padding: 4px;")
+            self._species_table.setStyleSheet(
+                "QTableWidget::item { color: black; }")
+            self._tau_display.setStyleSheet("color: #5d6d7e; font-size: 10px;")
+            self._flash_species_table.setStyleSheet(
+                "QTableWidget::item { color: black; }")
+            self._abs_adv_btn.setStyleSheet(
+                "QPushButton { text-align: left; font-size: 10px; "
+                "color: #5d6d7e; border: none; padding: 2px 0; background: transparent; }"
+                "QPushButton:checked { color: #0e6655; }")
 
     # ── form construction ─────────────────────────────────────────────────
 

--- a/ui/properties_panel.py
+++ b/ui/properties_panel.py
@@ -447,10 +447,10 @@ class PropertiesPanel(QWidget):
         self._run_btn.setObjectName("run_btn")
         self._run_btn.setFixedHeight(36)
         self._run_btn.setStyleSheet(
-            "QPushButton { background-color: #27ae60; color: white; border: none;"
+            "QPushButton { background-color: #000000; color: white; border: none;"
             " border-radius: 4px; font-weight: bold; font-size: 12px; }"
-            "QPushButton:hover { background-color: #1e8449; }"
-            "QPushButton:pressed { background-color: #196f3d; }"
+            "QPushButton:hover { background-color: #1a1a1a; }"
+            "QPushButton:pressed { background-color: #333333; }"
         )
         self._run_btn.clicked.connect(self._on_run)
         layout.addWidget(self._run_btn)

--- a/ui/results_panel.py
+++ b/ui/results_panel.py
@@ -27,7 +27,7 @@ class _Canvas(FigureCanvasQTAgg):
 
     def set_dark_mode(self, enabled: bool) -> None:
         self._dark = enabled
-        fig_bg = "#1e2328" if enabled else "white"
+        fig_bg = "#000000" if enabled else "white"
         self.fig.set_facecolor(fig_bg)
         for ax in self.fig.get_axes():
             self._apply_ax_style(ax)

--- a/ui/results_panel.py
+++ b/ui/results_panel.py
@@ -22,19 +22,56 @@ class _Canvas(FigureCanvasQTAgg):
         self.setParent(parent)
         self.fig = fig
         self._ax = None
+        self._dark = False
         self._show_placeholder()
+
+    def set_dark_mode(self, enabled: bool) -> None:
+        self._dark = enabled
+        fig_bg = "#1e2328" if enabled else "white"
+        self.fig.set_facecolor(fig_bg)
+        for ax in self.fig.get_axes():
+            self._apply_ax_style(ax)
+        self.draw_idle()
+
+    def _fig_bg(self) -> str:
+        return "#0f0f0f" if self._dark else "white"
+
+    def _ax_bg(self) -> str:
+        return "#111111" if self._dark else "#fafafa"
+
+    def _text_color(self) -> str:
+        return "#e8e8e8" if self._dark else "black"
+
+    def _apply_ax_style(self, ax) -> None:
+        tc = self._text_color()
+        ax.set_facecolor(self._ax_bg())
+        ax.tick_params(colors=tc, labelcolor=tc)
+        ax.xaxis.label.set_color(tc)
+        ax.yaxis.label.set_color(tc)
+        ax.title.set_color(tc)
+        for spine in ax.spines.values():
+            spine.set_edgecolor("#3d4450" if self._dark else "#cccccc")
+        legend = ax.get_legend()
+        if legend:
+            legend.get_frame().set_facecolor("#1a1a1a" if self._dark else "white")
+            legend.get_frame().set_edgecolor("#2a2a2a" if self._dark else "#cccccc")
+            for text in legend.get_texts():
+                text.set_color(tc)
 
     def _show_placeholder(self):
         self.fig.clear()
+        self.fig.set_facecolor(self._fig_bg())
         ax = self.fig.add_subplot(111)
         ax.text(0.5, 0.5, "Run a simulation to see results",
                 ha="center", va="center", transform=ax.transAxes,
                 color="#95a5a6", fontsize=11)
         ax.axis("off")
+        ax.set_facecolor(self._ax_bg())
         self.draw_idle()
 
     def plot_concentrations(self, results: dict):
         self.fig.clear()
+        self.fig.set_facecolor(self._fig_bg())
         ax = self.fig.add_subplot(111)
         t = results["t"]
         for i, (sp, conc) in enumerate(results["concentrations"].items()):
@@ -47,12 +84,13 @@ class _Canvas(FigureCanvasQTAgg):
         ax.set_xlim(0, t[-1])
         ax.set_ylim(bottom=0)
         ax.grid(True, alpha=0.3)
-        ax.set_facecolor("#fafafa")
+        self._apply_ax_style(ax)
         self.fig.tight_layout()
         self.draw_idle()
 
     def plot_conversion(self, results: dict):
         self.fig.clear()
+        self.fig.set_facecolor(self._fig_bg())
         ax = self.fig.add_subplot(111)
         t = results["t"]
         X = results["conversion"] * 100
@@ -64,12 +102,13 @@ class _Canvas(FigureCanvasQTAgg):
         ax.set_xlim(0, t[-1])
         ax.set_ylim(0, 105)
         ax.grid(True, alpha=0.3)
-        ax.set_facecolor("#fafafa")
+        self._apply_ax_style(ax)
         self.fig.tight_layout()
         self.draw_idle()
 
     def plot_temperature(self, results: dict):
         self.fig.clear()
+        self.fig.set_facecolor(self._fig_bg())
         ax = self.fig.add_subplot(111)
         t = results["t"]
         T = results["temperature"]
@@ -79,12 +118,13 @@ class _Canvas(FigureCanvasQTAgg):
         ax.set_title("Temperature vs. Time", fontsize=11, fontweight="bold")
         ax.set_xlim(0, t[-1])
         ax.grid(True, alpha=0.3)
-        ax.set_facecolor("#fafafa")
+        self._apply_ax_style(ax)
         self.fig.tight_layout()
         self.draw_idle()
 
     def plot_approach(self, results: dict):
         self.fig.clear()
+        self.fig.set_facecolor(self._fig_bg())
         ax = self.fig.add_subplot(111)
         t = results["t"]
         A = results["approach"]
@@ -96,13 +136,14 @@ class _Canvas(FigureCanvasQTAgg):
         ax.set_xlim(0, t[-1])
         ax.set_ylim(0, 105)
         ax.grid(True, alpha=0.3)
-        ax.set_facecolor("#fafafa")
+        self._apply_ax_style(ax)
         self.fig.tight_layout()
         self.draw_idle()
 
     def plot_flash_phase(self, results: dict, phase: str):
         """Plot mole fraction vs time for vapor (y_i) or liquid (x_i)."""
         self.fig.clear()
+        self.fig.set_facecolor(self._fig_bg())
         ax = self.fig.add_subplot(111)
         t = results["t"]
         data = results[phase]  # "vapor" or "liquid"
@@ -118,13 +159,14 @@ class _Canvas(FigureCanvasQTAgg):
         ax.set_xlim(0, t[-1])
         ax.set_ylim(0, 1.05)
         ax.grid(True, alpha=0.3)
-        ax.set_facecolor("#fafafa")
+        self._apply_ax_style(ax)
         self.fig.tight_layout()
         self.draw_idle()
 
     def plot_flash_psi(self, results: dict):
         """Plot vapor fraction ψ(t)."""
         self.fig.clear()
+        self.fig.set_facecolor(self._fig_bg())
         ax = self.fig.add_subplot(111)
         t = results["t"]
         psi = results["psi"]
@@ -136,13 +178,14 @@ class _Canvas(FigureCanvasQTAgg):
         ax.set_xlim(0, t[-1])
         ax.set_ylim(0, 1.05)
         ax.grid(True, alpha=0.3)
-        ax.set_facecolor("#fafafa")
+        self._apply_ax_style(ax)
         self.fig.tight_layout()
         self.draw_idle()
 
     def plot_absorption_profiles(self, results: dict):
         """Tab 0: y(z), y*(z) on left axis; x(z) on right axis."""
         self.fig.clear()
+        self.fig.set_facecolor(self._fig_bg())
         ax = self.fig.add_subplot(111)
         z = results["z"]
         ax.plot(z, results["y"],      color="#2980b9", linewidth=2, label="y (gas)")
@@ -156,20 +199,27 @@ class _Canvas(FigureCanvasQTAgg):
         ax2.set_ylabel("Liquid mole fraction x (−)", fontsize=10, color="#e74c3c")
         ax2.tick_params(axis="y", labelcolor="#e74c3c")
         ax.set_xlim(0, z[-1])
+        tc = self._text_color()
         ax.set_title("Composition Profiles along Column Height",
-                     fontsize=11, fontweight="bold")
+                     fontsize=11, fontweight="bold", color=tc)
         ax.grid(True, alpha=0.3)
-        ax.set_facecolor("#fafafa")
+        self._apply_ax_style(ax)
+        self._apply_ax_style(ax2)
+        # Restore per-axis y-label colors (overridden by _apply_ax_style)
+        ax.yaxis.label.set_color("#2980b9")
+        ax2.yaxis.label.set_color("#e74c3c")
         # Combined legend
         lines1, labels1 = ax.get_legend_handles_labels()
         lines2, labels2 = ax2.get_legend_handles_labels()
         ax.legend(lines1 + lines2, labels1 + labels2, fontsize=9, framealpha=0.9)
+        self._apply_ax_style(ax)  # re-apply to update legend after it's created
         self.fig.tight_layout()
         self.draw_idle()
 
     def plot_hetp_profile(self, results: dict):
         """Tab 1: HOG(z) and HETP(z) with mean reference lines."""
         self.fig.clear()
+        self.fig.set_facecolor(self._fig_bg())
         ax = self.fig.add_subplot(111)
         z = results["z"]
         ax.plot(z, results["HOG"],  color="#1abc9c", linewidth=2, label="HOG")
@@ -185,13 +235,14 @@ class _Canvas(FigureCanvasQTAgg):
         ax.set_xlim(0, z[-1])
         ax.set_ylim(bottom=0)
         ax.grid(True, alpha=0.3)
-        ax.set_facecolor("#fafafa")
+        self._apply_ax_style(ax)
         self.fig.tight_layout()
         self.draw_idle()
 
     def plot_transfer_coefficients(self, results: dict):
         """Tab 2: k_G·a, k_L·a, K_OG·a along z."""
         self.fig.clear()
+        self.fig.set_facecolor(self._fig_bg())
         ax = self.fig.add_subplot(111)
         z = results["z"]
         ax.plot(z, results["kG_a"],  color="#2980b9", linewidth=2, label="$k_G a$")
@@ -205,12 +256,13 @@ class _Canvas(FigureCanvasQTAgg):
         ax.set_xlim(0, z[-1])
         ax.set_ylim(bottom=0)
         ax.grid(True, alpha=0.3)
-        ax.set_facecolor("#fafafa")
+        self._apply_ax_style(ax)
         self.fig.tight_layout()
         self.draw_idle()
 
     def plot_mass_balance(self, results: dict):
         self.fig.clear()
+        self.fig.set_facecolor(self._fig_bg())
         ax = self.fig.add_subplot(111)
         t = results["t"]
         streams = results["streams"]
@@ -233,7 +285,7 @@ class _Canvas(FigureCanvasQTAgg):
         ax.set_xlim(0, t[-1])
         ax.set_ylim(bottom=0)
         ax.grid(True, alpha=0.3)
-        ax.set_facecolor("#fafafa")
+        self._apply_ax_style(ax)
         self.fig.tight_layout()
         self.draw_idle()
 
@@ -245,12 +297,12 @@ class ResultsPanel(QWidget):
         layout.setContentsMargins(0, 0, 0, 0)
 
         # Header bar
-        header = QLabel("  Simulation Results")
-        header.setFixedHeight(28)
-        header.setStyleSheet(
+        self._header = QLabel("  Simulation Results")
+        self._header.setFixedHeight(28)
+        self._header.setStyleSheet(
             "background-color: #1a5276; color: white;"
             "font-size: 11px; font-weight: bold;")
-        layout.addWidget(header)
+        layout.addWidget(self._header)
 
         self._tabs = QTabWidget()
         layout.addWidget(self._tabs)
@@ -273,6 +325,19 @@ class ResultsPanel(QWidget):
         self._tabs.addTab(self._mb_canvas, "Mass Balance")
         self._tabs.setTabVisible(2, False)
         self._tabs.setTabVisible(4, False)
+
+    def set_dark_mode(self, enabled: bool) -> None:
+        for canvas in (self._conc_canvas, self._conv_canvas,
+                       self._extra_canvas, self._mb_canvas):
+            canvas.set_dark_mode(enabled)
+        if enabled:
+            self._header.setStyleSheet(
+                "background-color: #111111; color: #e8e8e8;"
+                "font-size: 11px; font-weight: bold;")
+        else:
+            self._header.setStyleSheet(
+                "background-color: #1a5276; color: white;"
+                "font-size: 11px; font-weight: bold;")
 
     def display(self, results: dict, reactor_name: str = ""):
         self._tabs.setTabVisible(2, False)

--- a/ui/styles.py
+++ b/ui/styles.py
@@ -1,4 +1,4 @@
-APP_STYLESHEET = """
+LIGHT_STYLESHEET = """
 /* ── Main window ── */
 QMainWindow {
     background-color: #ecf0f1;
@@ -119,7 +119,7 @@ QPushButton {
     color: #2c3e50;
     border: 1px solid #aab7b8;
     border-radius: 4px;
-    padding: 6px 16px;
+padding: 6px 16px;
     font-size: 12px;
 }
 QPushButton:hover {
@@ -193,6 +193,42 @@ QHeaderView::section {
     font-weight: bold;
 }
 
+/* ── Scroll bars ── */
+QScrollBar:vertical {
+    background: #f0f2f3;
+    width: 10px;
+    margin: 0;
+    border-radius: 5px;
+}
+QScrollBar::handle:vertical {
+    background: #b2bec3;
+    min-height: 24px;
+    border-radius: 5px;
+}
+QScrollBar::handle:vertical:hover {
+    background: #95a5a6;
+}
+QScrollBar::add-line:vertical, QScrollBar::sub-line:vertical {
+    height: 0;
+}
+QScrollBar:horizontal {
+    background: #f0f2f3;
+    height: 10px;
+    margin: 0;
+    border-radius: 5px;
+}
+QScrollBar::handle:horizontal {
+    background: #b2bec3;
+    min-width: 24px;
+    border-radius: 5px;
+}
+QScrollBar::handle:horizontal:hover {
+    background: #95a5a6;
+}
+QScrollBar::add-line:horizontal, QScrollBar::sub-line:horizontal {
+    width: 0;
+}
+
 /* ── Status bar ── */
 QStatusBar {
     background-color: #2c3e50;
@@ -203,3 +239,265 @@ QStatusBar::item {
     border: none;
 }
 """
+
+DARK_STYLESHEET = """
+/* ── Main window ── */
+QMainWindow {
+    background-color: #0f0f0f;
+}
+QWidget {
+    background-color: #0f0f0f;
+    color: #e8e8e8;
+}
+
+/* ── Menu bar ── */
+QMenuBar {
+    background-color: #0a0a0a;
+    color: #e8e8e8;
+    font-size: 13px;
+    padding: 2px 4px;
+}
+QMenuBar::item:selected {
+    background-color: #1e1e1e;
+    border-radius: 3px;
+}
+QMenu {
+    background-color: #111111;
+    color: #e8e8e8;
+    border: 1px solid #2a2a2a;
+}
+QMenu::item:selected {
+    background-color: #2980b9;
+}
+QMenu::separator {
+    height: 1px;
+    background: #2a2a2a;
+    margin: 3px 10px;
+}
+
+/* ── Toolbar ── */
+QToolBar {
+    background-color: #111111;
+    border-bottom: 1px solid #2a2a2a;
+    spacing: 4px;
+    padding: 3px 6px;
+}
+QToolBar QToolButton {
+    background-color: #1a4a6e;
+    color: #e8e8e8;
+    border: none;
+    border-radius: 4px;
+    padding: 5px 12px;
+    font-size: 12px;
+    font-weight: bold;
+    min-width: 80px;
+}
+QToolBar QToolButton:hover {
+    background-color: #2980b9;
+}
+QToolBar QToolButton:pressed {
+    background-color: #1f618d;
+}
+QToolBar::separator {
+    width: 1px;
+    background: #2a2a2a;
+    margin: 4px 6px;
+}
+
+/* ── Dock widgets ── */
+QDockWidget {
+    font-size: 12px;
+    font-weight: bold;
+    color: #e8e8e8;
+}
+QDockWidget::title {
+    background-color: #111111;
+    color: #e8e8e8;
+    padding: 5px 8px;
+    text-align: left;
+}
+
+/* ── Group boxes ── */
+QGroupBox {
+    font-size: 11px;
+    font-weight: bold;
+    color: #a0c8e8;
+    border: 1px solid #2a2a2a;
+    border-radius: 5px;
+    margin-top: 10px;
+    padding-top: 6px;
+}
+QGroupBox::title {
+    subcontrol-origin: margin;
+    left: 10px;
+    padding: 0 4px;
+    background-color: #0f0f0f;
+}
+
+/* ── Input widgets ── */
+QDoubleSpinBox, QSpinBox, QLineEdit, QComboBox {
+    border: 1px solid #2a2a2a;
+    border-radius: 3px;
+    padding: 3px 6px;
+    background-color: #1a1a1a;
+    font-size: 12px;
+    min-height: 22px;
+    color: #e8e8e8;
+}
+QDoubleSpinBox:focus, QSpinBox:focus,
+QLineEdit:focus, QComboBox:focus {
+    border: 1px solid #2980b9;
+}
+QComboBox::drop-down {
+    border: none;
+    width: 20px;
+}
+QComboBox QAbstractItemView {
+    background-color: #1a1a1a;
+    color: #e8e8e8;
+    border: 1px solid #2a2a2a;
+    selection-background-color: #2980b9;
+}
+
+/* ── Labels ── */
+QLabel {
+    color: #e8e8e8;
+    font-size: 12px;
+}
+
+/* ── Buttons ── */
+QPushButton {
+    background-color: #1a1a1a;
+    color: #e8e8e8;
+    border: 1px solid #2a2a2a;
+    border-radius: 4px;
+    padding: 6px 16px;
+    font-size: 12px;
+}
+QPushButton:hover {
+    background-color: #242424;
+}
+QPushButton:pressed {
+    background-color: #2e2e2e;
+}
+QPushButton#run_btn {
+    background-color: #1e8449;
+    color: white;
+    border: none;
+    font-weight: bold;
+}
+QPushButton#run_btn:hover {
+    background-color: #27ae60;
+}
+QPushButton#run_btn:pressed {
+    background-color: #196f3d;
+}
+
+/* ── Check box ── */
+QCheckBox {
+    font-size: 12px;
+    color: #e8e8e8;
+    spacing: 6px;
+}
+
+/* ── Scroll area ── */
+QScrollArea {
+    border: none;
+    background-color: transparent;
+}
+
+/* ── Tab widget ── */
+QTabWidget::pane {
+    border: 1px solid #2a2a2a;
+    background-color: #111111;
+}
+QTabBar::tab {
+    background-color: #111111;
+    color: #888888;
+    padding: 6px 14px;
+    border: 1px solid #2a2a2a;
+    border-bottom: none;
+    font-size: 12px;
+    min-width: 100px;
+}
+QTabBar::tab:selected {
+    background-color: #0f0f0f;
+    color: #e8e8e8;
+    font-weight: bold;
+}
+QTabBar::tab:hover:!selected {
+    background-color: #1a1a1a;
+}
+
+/* ── Table ── */
+QTableWidget {
+    gridline-color: #2a2a2a;
+    font-size: 11px;
+    background-color: #0f0f0f;
+    color: #e8e8e8;
+    selection-background-color: #1a3a5c;
+    alternate-background-color: #141414;
+}
+QHeaderView::section {
+    background-color: #111111;
+    color: #e8e8e8;
+    padding: 4px 8px;
+    border: none;
+    border-right: 1px solid #2a2a2a;
+    font-size: 11px;
+    font-weight: bold;
+}
+
+/* ── Status bar ── */
+QStatusBar {
+    background-color: #0a0a0a;
+    color: #e8e8e8;
+    font-size: 11px;
+}
+QStatusBar::item {
+    border: none;
+}
+
+/* ── Scroll bars ── */
+QScrollBar:vertical {
+    background: #1a1a1a;
+    width: 10px;
+    margin: 0;
+    border-radius: 5px;
+}
+QScrollBar::handle:vertical {
+    background: #3a3a3a;
+    min-height: 24px;
+    border-radius: 5px;
+}
+QScrollBar::handle:vertical:hover {
+    background: #555555;
+}
+QScrollBar::add-line:vertical, QScrollBar::sub-line:vertical {
+    height: 0;
+}
+QScrollBar:horizontal {
+    background: #1a1a1a;
+    height: 10px;
+    margin: 0;
+    border-radius: 5px;
+}
+QScrollBar::handle:horizontal {
+    background: #3a3a3a;
+    min-width: 24px;
+    border-radius: 5px;
+}
+QScrollBar::handle:horizontal:hover {
+    background: #555555;
+}
+QScrollBar::add-line:horizontal, QScrollBar::sub-line:horizontal {
+    width: 0;
+}
+
+/* ── Splitter ── */
+QSplitter::handle {
+    background-color: #2a2a2a;
+}
+"""
+
+APP_STYLESHEET = LIGHT_STYLESHEET

--- a/ui/styles.py
+++ b/ui/styles.py
@@ -147,6 +147,20 @@ QCheckBox {
     color: #2c3e50;
     spacing: 6px;
 }
+QCheckBox::indicator {
+    width: 14px;
+    height: 14px;
+    border: 2px solid #7f8c8d;
+    border-radius: 3px;
+    background-color: white;
+}
+QCheckBox::indicator:checked {
+    background-color: #2980b9;
+    border-color: #2980b9;
+}
+QCheckBox::indicator:hover {
+    border-color: #2980b9;
+}
 
 /* ── Scroll area ── */
 QScrollArea {
@@ -399,6 +413,20 @@ QCheckBox {
     color: #e8e8e8;
     spacing: 6px;
 }
+QCheckBox::indicator {
+    width: 14px;
+    height: 14px;
+    border: 2px solid #555555;
+    border-radius: 3px;
+    background-color: #1a1a1a;
+}
+QCheckBox::indicator:checked {
+    background-color: #2980b9;
+    border-color: #2980b9;
+}
+QCheckBox::indicator:hover {
+    border-color: #2980b9;
+}
 
 /* ── Scroll area ── */
 QScrollArea {
@@ -500,4 +528,4 @@ QSplitter::handle {
 }
 """
 
-APP_STYLESHEET = LIGHT_STYLESHEET
+APP_STYLESHEET = DARK_STYLESHEET

--- a/ui/styles.py
+++ b/ui/styles.py
@@ -155,8 +155,9 @@ QCheckBox::indicator {
     background-color: white;
 }
 QCheckBox::indicator:checked {
-    background-color: #2980b9;
-    border-color: #2980b9;
+    background-color: #2c3e50;
+    border-color: #2c3e50;
+    image: url(ui/check.svg);
 }
 QCheckBox::indicator:hover {
     border-color: #2980b9;
@@ -421,8 +422,9 @@ QCheckBox::indicator {
     background-color: #1a1a1a;
 }
 QCheckBox::indicator:checked {
-    background-color: #2980b9;
-    border-color: #2980b9;
+    background-color: #1a1a1a;
+    border-color: #555555;
+    image: url(ui/check.svg);
 }
 QCheckBox::indicator:hover {
     border-color: #2980b9;


### PR DESCRIPTION
## Summary

- Two-finger scroll now pans the canvas; pinch gesture zooms in/out
- `PalettePanel` and `EquipmentTile` support dark mode via `set_dark_mode()`
- `ResultsPanel` dark background updated to pure black
- Various canvas and UI fixes accumulated on this branch

## Test plan

- [ ] Open the app and verify two-finger scroll pans the flowsheet
- [ ] Pinch in/out on trackpad to confirm zoom works with min/max clamp
- [ ] Toggle dark mode and verify palette tiles update correctly
- [ ] Confirm issues #1, #4, #7 are resolved

Closes #1, #4, #7